### PR TITLE
feat(observable): implement skip and take_last operators

### DIFF
--- a/docs/OPERATORS.md
+++ b/docs/OPERATORS.md
@@ -115,6 +115,24 @@ mut l := rxv.just[int](10, 20, 30).last()
 // emits: 30
 ```
 
+### `.skip(n)`
+
+Suppresses the first `n` items emitted by the source.
+
+```v ignore
+mut obs := rxv.just[int](1, 2, 3, 4, 5).skip(2)
+// emits: 3, 4, 5
+```
+
+### `.take_last(n)`
+
+Emits only the last `n` items from the source.
+
+```v ignore
+mut obs := rxv.just[int](1, 2, 3, 4, 5).take_last(2)
+// emits: 4, 5
+```
+
 ### `.distinct`
 
 Suppresses all items already seen.

--- a/observable.v
+++ b/observable.v
@@ -477,6 +477,94 @@ pub fn (mut o ObservableImpl[T]) last(opts ...RxOption) &ObservableImpl[T] {
 	}
 }
 
+// ---- skip ----------------------------------------------------------------
+
+fn obs_skip_run[T](n u32, src chan Item[T], next chan Item[T]) {
+	mut skipped := u32(0)
+	for {
+		mut item := Item[T]{
+			has_value: false
+			err:       none
+		}
+		s := src.try_pop(mut item)
+		if s == .success {
+			if item.is_error() {
+				next <- item
+				break
+			}
+			if item.has_value {
+				if skipped < n {
+					skipped++
+				} else {
+					next <- item
+				}
+			}
+		} else if s == .closed {
+			break
+		} else {
+			time.sleep(poll_sleep)
+		}
+	}
+	next.close()
+}
+
+// skip suppresses the first n items emitted by the source.
+pub fn (mut o ObservableImpl[T]) skip(n u32, opts ...RxOption) &ObservableImpl[T] {
+	mut option := parse_options(...opts)
+	next := option.build_channel_t[T]()
+	src := o.ch
+	spawn obs_skip_run[T](n, src, next)
+	return &ObservableImpl[T]{
+		ch:     next
+		parent: o.parent
+	}
+}
+
+// ---- take_last -----------------------------------------------------------
+
+fn obs_take_last_run[T](n u32, src chan Item[T], next chan Item[T]) {
+	mut window := []Item[T]{}
+	for {
+		mut item := Item[T]{
+			has_value: false
+			err:       none
+		}
+		s := src.try_pop(mut item)
+		if s == .success {
+			if item.is_error() {
+				next <- item
+				break
+			}
+			if item.has_value {
+				window << item
+				if window.len > int(n) {
+					window.delete(0)
+				}
+			}
+		} else if s == .closed {
+			for i in 0 .. window.len {
+				next <- window[i]
+			}
+			break
+		} else {
+			time.sleep(poll_sleep)
+		}
+	}
+	next.close()
+}
+
+// take_last emits only the last n items from the source.
+pub fn (mut o ObservableImpl[T]) take_last(n u32, opts ...RxOption) &ObservableImpl[T] {
+	mut option := parse_options(...opts)
+	next := option.build_channel_t[T]()
+	src := o.ch
+	spawn obs_take_last_run[T](n, src, next)
+	return &ObservableImpl[T]{
+		ch:     next
+		parent: o.parent
+	}
+}
+
 // ---- timeout --------------------------------------------------------------
 // NOTE: timeout_ms granularity is ~10µs poll intervals.
 // A value of 0 disables the timeout.

--- a/skip_take_last_test.v
+++ b/skip_take_last_test.v
@@ -1,0 +1,115 @@
+import rxv
+
+fn test_skip() {
+	mut obs := rxv.just[int](1, 2, 3, 4, 5)
+	mut result := obs.skip(2)
+	ch := result.observe()
+	mut item := rxv.Item[int]{
+		has_value: false
+		err:       none
+	}
+	mut values := []int{}
+	for {
+		s := ch.try_pop(mut item)
+		if s == .success {
+			if item.has_value {
+				values << item.get_value()
+			}
+		} else if s == .closed {
+			break
+		} else {
+			continue
+		}
+	}
+	assert values == [3, 4, 5]
+}
+
+fn test_skip_more_than_total() {
+	mut obs := rxv.just[int](1, 2)
+	mut result := obs.skip(5)
+	ch := result.observe()
+	mut item := rxv.Item[int]{
+		has_value: false
+		err:       none
+	}
+	mut values := []int{}
+	for {
+		s := ch.try_pop(mut item)
+		if s == .success {
+			if item.has_value {
+				values << item.get_value()
+			}
+		} else if s == .closed {
+			break
+		} else {
+			continue
+		}
+	}
+	assert values == []
+}
+
+fn test_take_last() {
+	mut obs := rxv.just[int](1, 2, 3, 4, 5)
+	mut result := obs.take_last(2)
+	ch := result.observe()
+	mut item := rxv.Item[int]{
+		has_value: false
+		err:       none
+	}
+	mut values := []int{}
+	for {
+		s := ch.try_pop(mut item)
+		if s == .success {
+			if item.has_value {
+				values << item.get_value()
+			}
+		} else if s == .closed {
+			break
+		} else {
+			continue
+		}
+	}
+	assert values == [4, 5]
+}
+
+fn test_take_last_one() {
+	mut obs := rxv.just[int](10, 20, 30)
+	mut result := obs.take_last(1)
+	ch := result.observe()
+	mut item := rxv.Item[int]{
+		has_value: false
+		err:       none
+	}
+	for {
+		s := ch.try_pop(mut item)
+		if s == .success || s == .closed {
+			break
+		}
+	}
+	assert item.has_value
+	assert item.get_value() == 30
+}
+
+fn test_take_last_more_than_total() {
+	mut obs := rxv.just[int](1, 2)
+	mut result := obs.take_last(5)
+	ch := result.observe()
+	mut item := rxv.Item[int]{
+		has_value: false
+		err:       none
+	}
+	mut values := []int{}
+	for {
+		s := ch.try_pop(mut item)
+		if s == .success {
+			if item.has_value {
+				values << item.get_value()
+			}
+		} else if s == .closed {
+			break
+		} else {
+			continue
+		}
+	}
+	assert values == [1, 2]
+}


### PR DESCRIPTION
Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `.skip()` operator to suppress the first n emitted items
  * Added `.take_last()` operator to emit only the last n items

* **Documentation**
  * Added documentation for `.skip()` and `.take_last()` operators

* **Tests**
  * Added comprehensive test coverage for both operators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->